### PR TITLE
Fix missing fields and quality filtering in neuron_extracellular document creation

### DIFF
--- a/SpikeDataExtraction/+vhNDISpikeSorter/import_sorted_units.m
+++ b/SpikeDataExtraction/+vhNDISpikeSorter/import_sorted_units.m
@@ -59,9 +59,18 @@ function import_sorted_units(ndiSession, probe)
             
             if exist(infoFullPath, 'file')
                 tmp = load(infoFullPath);
-                if isfield(tmp, 'clusterinfo') && isfield(tmp.clusterinfo, 'quality_label')
-                    quality = tmp.clusterinfo.quality_label;
+                if isfield(tmp, 'clusterinfo')
+                    if isfield(tmp.clusterinfo, 'quality_label')
+                        quality = tmp.clusterinfo.quality_label;
+                    elseif isfield(tmp.clusterinfo, 'qualitylabel')
+                        quality = tmp.clusterinfo.qualitylabel;
+                    end
                 end
+            end
+            
+            % Skip if quality is 'not usable' or 'garbage'
+            if strcmpi(quality, 'not usable') || strcmpi(quality, 'garbage')
+                continue;
             end
             
             if ~isKey(clusterData, cID)
@@ -97,6 +106,7 @@ function import_sorted_units(ndiSession, probe)
         neuron_extracellular.quality_label = qLabel;
         
         all_waveforms = [];
+        h_struct = [];
         
         for m = 1:length(dataStruct)
             eID = dataStruct(m).epochID;
@@ -116,6 +126,8 @@ function import_sorted_units(ndiSession, probe)
                 
                 if ~isempty(indices)
                     [w_epoch, h] = readvhlspikewaveformfile(wFile);
+                    if isempty(h_struct), h_struct = h; end
+                    
                     % w_epoch is S x C x N
                     w_unit = w_epoch(:, :, indices);
                     
@@ -134,6 +146,47 @@ function import_sorted_units(ndiSession, probe)
         end
         
         neuron_extracellular.mean_waveform = mean_wave;
+        
+        if ~isempty(mean_wave)
+            neuron_extracellular.number_of_channels = size(mean_wave, 2);
+            neuron_extracellular.number_of_samples_per_channel = size(mean_wave, 1);
+        else
+            neuron_extracellular.number_of_channels = 0;
+            neuron_extracellular.number_of_samples_per_channel = 0;
+        end
+        
+        % Quality number mapping
+        % Using integer scale: Excellent=4, Good=3, Fair=2, Poor=1, Multi=0, Unselected=0, Garbage=-1
+        quality_map = containers.Map({'excellent', 'good', 'fair', 'poor', 'multi', 'garbage', 'multi-unit', 'unselected', 'not usable'}, ...
+            {4, 3, 2, 1, 0, -1, 0, 0, -1});
+        
+        qNum = 0; % Default
+        if ~isempty(qLabel)
+             lowQ = lower(qLabel);
+             if isKey(quality_map, lowQ)
+                 qNum = quality_map(lowQ);
+             end
+        end
+        neuron_extracellular.quality_number = int8(qNum);
+        
+        % Waveform sample times
+        sr = 20000; % Default fallback
+        if ~isempty(h_struct)
+            if isfield(h_struct, 'samplerate')
+                sr = h_struct.samplerate;
+            elseif isfield(h_struct, 'sampling_rate')
+                sr = h_struct.sampling_rate;
+            elseif isfield(h_struct, 'frequency')
+                sr = h_struct.frequency;
+            end
+        end
+        
+        num_samples = neuron_extracellular.number_of_samples_per_channel;
+        if num_samples > 0
+            neuron_extracellular.waveform_sample_times = (0:num_samples-1) / sr;
+        else
+            neuron_extracellular.waveform_sample_times = [];
+        end
         
         neuron_doc = ndi.document('neuron_extracellular', ...
             'neuron_extracellular', neuron_extracellular, ...


### PR DESCRIPTION
Fixed an error where `import_sorted_units.m` failed due to missing fields in the `neuron_extracellular` document. The error message indicated that `number_of_channels`, `number_of_samples_per_channel`, `quality_number`, and `waveform_sample_times` were expected but not found.

Also addressed user feedback regarding missing quality labels and the need to filter out unusable units.

Changes:
- Modified `SpikeDataExtraction/+vhNDISpikeSorter/import_sorted_units.m` to:
    - Capture the waveform file header (`h`) to extract sampling rate.
    - Calculate `number_of_channels` and `number_of_samples_per_channel` from the `mean_waveform` dimensions.
    - Generate `waveform_sample_times` based on the sampling rate (defaulting to 20kHz if not found).
    - Support reading `qualitylabel` (no underscore) from `clusterinfo` files, as generated by `cluster_spikewaves_gui`.
    - Map the `quality_label` string to a numeric `quality_number` using an expanded map (including 'multi-unit', 'unselected', 'not usable').
    - skip importing units if the quality is 'not usable' or 'garbage'.
- This ensures compliance with the expected NDI document schema and user requirements.

---
*PR created automatically by Jules for task [7786535370472527944](https://jules.google.com/task/7786535370472527944) started by @stevevanhooser*